### PR TITLE
re-do dockerfile to build from scratch alpine, fix solc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,24 @@
-FROM rust:alpine as builder
-
-ENV GLIBC_REPO=https://github.com/sgerrand/alpine-pkg-glibc
-ENV GLIBC_VERSION=2.35-r0
-
-RUN set -ex && apk update \
-    && apk add --no-cache ca-certificates \
-        curl bash git jq build-base linux-headers libstdc++ ca-certificates \
-    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub; \
-    for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION}; \
-        do curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done \
-    && apk add --no-cache /tmp/*.apk \
-    && rm /tmp/*.apk
-
-WORKDIR /usr/src/foundry
+from alpine as build-environment
+WORKDIR /opt
+RUN apk add clang lld curl build-base linux-headers \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rustup.sh \
+    && chmod +x ./rustup.sh \
+    && ./rustup.sh -y
+WORKDIR /opt/foundry
 COPY . .
+RUN source $HOME/.profile && cargo build --release \
+    && strip /opt/foundry/target/release/forge \
+    && strip /opt/foundry/target/release/cast
 
-ENV RUSTFLAGS="-C target-cpu=native"
-RUN cargo build --release
+from alpine as foundry-client
+ENV GLIBC_KEY=https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+ENV GLIBC_KEY_FILE=/etc/apk/keys/sgerrand.rsa.pub
+ENV GLIBC_RELEASE=https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk
 
-RUN strip /usr/src/foundry/target/release/cast \
-    && strip /usr/src/foundry/target/release/forge
-
-FROM alpine:latest
-
-COPY --from=builder /usr/src/foundry/target/release/cast /usr/local/bin/cast
-COPY --from=builder /usr/src/foundry/target/release/forge /usr/local/bin/forge
-
-ENTRYPOINT ["/bin/sh", "-c"]
+RUN apk add linux-headers gcompat
+RUN wget -q -O ${GLIBC_KEY_FILE} ${GLIBC_KEY} \
+    && wget -O glibc.apk ${GLIBC_RELEASE} \
+    && apk add glibc.apk --force
+COPY --from=build-environment /opt/foundry/target/release/forge /usr/local/bin/forge
+COPY --from=build-environment /opt/foundry/target/release/cast /usr/local/bin/cast
+ENTRYPOINT ["/bin/sh -c"]


### PR DESCRIPTION
Modifies Dockerfile from your PR https://github.com/gakonst/foundry/pull/981 to handle the solc issues we saw.
Final image size is 20mb compressed and 42.9 mb uncompressed.

Hosted a built container image here: https://github.com/dmfxyz/foundry/pkgs/container/foundry